### PR TITLE
Update main prophet plotting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bleach==6.2.0
 bokeh==3.7.2
 bokeh_sampledata==2024.2
+catboost==1.2.7
 certifi==2025.1.31
 charset-normalizer==3.4.1
 cmdstanpy==1.2.5
@@ -9,6 +10,7 @@ colorcet==3.1.0
 contourpy==1.3.1
 cycler==0.12.1
 fonttools==4.57.0
+graphviz==0.20.3
 holidays==0.69
 holoviews==1.20.2
 icalendar==6.1.3
@@ -25,12 +27,13 @@ matplotlib==3.10.1
 mdit-py-plugins==0.4.2
 mdurl==0.1.2
 narwhals==1.33.0
-numpy==2.2.4
+numpy==1.26.4
 packaging==24.2
 pandas==2.2.3
 panel==1.6.2
 param==2.2.0
 pillow==11.1.0
+plotly==6.0.1
 prophet==1.1.6
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
@@ -50,4 +53,5 @@ tzdata==2025.2
 uc-micro-py==1.0.3
 urllib3==2.3.0
 webencodings==0.5.1
+xgboost==3.0.0
 xyzservices==2025.1.0


### PR DESCRIPTION
Updated time series plots to include forecasts for `fare`, `fare_lg`, and `fare_low`
* added new class variables to store dataframes
* updated how dates are handled for quarters e.g. 2024-Q1 --> 2024-03-31 (quarter end)
* Prophet models are no longer run when Analyze button is clicked
  * instead all forecast dataframes are preloaded from a json file
  * and a desired route dataframe is looked up via a dictionary search
* updated interaction where line chart will reset when the origin or destination input changes
  * prevents old forecasts from appearing on new line chart